### PR TITLE
fixed packet size counting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GRC Bit Converter (grc_bit_converter.py) is a python script for parsing and prin
 * Author: Don C. Weber (cutaway) - [@cutaway](http://twitter.com/cutaway)
 * Company: [InGuardians, Inc.](http://inguardians.com)
 * Start Date: May 15, 2014
-* Contributers: Be the first
+* Contributers: Geno Nullfree <nullfree.geno@gmail.com>
 
 ## Requirements:
 
@@ -18,6 +18,7 @@ GRC Bit Converter (grc_bit_converter.py) is a python script for parsing and prin
 ```
 grc_bit_converter.py: 
     -f <file>:       Input file (required)"
+    -o <file>:       Output file (enabling this will silence all other output)"
     -p <size>:       Size of the packet (defaults to 250)"
     -s <string>:     Search for a string. This will also supress packet printing."
     -i:              Invert the bits of the byte. This may be necessary if high"

--- a/grc_bit_converter.py
+++ b/grc_bit_converter.py
@@ -122,17 +122,11 @@ if coded:
     for cnt in range(len(ind)):
         if ord(ind[cnt]) > 1:
             # Build each packet
-            if cnt:
-                packets.append(ind[cnt:cnt+(max_packet*8)])
-            else:
-                packets.append(ind[cnt:(cnt+1)+(max_packet*8)])
+            packets.append(ind[cnt:(cnt+1)+(max_packet*8)])
 else:
     # Process all bytes as packets
     for cnt in range(bypass,len(ind),(max_packet*8)):
-        if cnt:
-            packets.append(ind[cnt:cnt+(max_packet*8)])
-        else:
-            packets.append(ind[cnt:(cnt+1)+(max_packet*8)])
+        packets.append(ind[cnt:(cnt+1)+(max_packet*8)])
 
 # Process all packets
 print "Starting Packet Parsing."


### PR DESCRIPTION
The if statements would correctly count the first packet size correctly, but the following packets were truncated by 2 bytes. The data was masked/ignored, so the total length was still correct, but each full packet other than the first one was 2 bytes short.
